### PR TITLE
Removing warning

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -224,6 +224,7 @@ export default class TextField extends PureComponent {
     let options = {
       toValue: this.focusState(),
       duration,
+      useNativeDriver: false,
     };
 
     startAnimation(focusAnimation, options, this.onFocusAnimationEnd);


### PR DESCRIPTION
Removing warning: `useNativeDriver` was not specified.